### PR TITLE
Add updateCLI for golang and traefik tags

### DIFF
--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -1,0 +1,59 @@
+name: "Updatecli: Dependency Management"
+
+on:
+  schedule:
+    # Runs at 06 PM UTC
+    - cron: '0 18 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+        with:
+          version: v0.110.2
+
+      - name: Delete leftover UpdateCLI branches
+        run: |
+          gh pr list \
+            --search "is:closed is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > closed_prs_branches.txt
+          gh pr list \
+            --search "is:open is:pr head:updatecli_" \
+            --json headRefName \
+            --jq ".[].headRefName" | sort -u > open_prs_branches.txt
+          for branch in $(comm -23 closed_prs_branches.txt open_prs_branches.txt); do
+            if (git ls-remote --exit-code --heads origin "$branch"); then
+              echo "Deleting leftover UpdateCLI branch - $branch";
+              git push origin --delete "$branch";
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Apply Updatecli
+        # Never use '--debug' option, because it might leak the access tokens.
+        run: "updatecli apply --clean --config ./updatecli/updatecli.d/ --values ./updatecli/values.yaml"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ endif
 REPO ?= rancher
 PKG ?= github.com/traefik/traefik/v3
 BUILD_META=-build$(shell date +%Y%m%d)
-TAG ?= $(if $(GITHUB_ACTION_TAG),$(GITHUB_ACTION_TAG),v3.5.0$(BUILD_META))
+TAG ?= ${GITHUB_ACTION_TAG}
+
+ifeq ($(TAG),)
+TAG := v3.5.0$(BUILD_META)
+endif
+
 ifeq (,$(filter %$(BUILD_META),$(TAG)))
 $(error TAG needs to end with build metadata: $(BUILD_META))
 endif

--- a/updatecli/updatecli.d/updatebuildbase.yaml
+++ b/updatecli/updatecli.d/updatebuildbase.yaml
@@ -1,0 +1,84 @@
+---
+name: "Update build base version"
+
+sources:
+  # Read the current version from the Dockerfile
+  current_minor:
+    name: Get current build base minor version from Dockerfile
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: GO_IMAGE
+    transformers:
+      # Value is "rancher/hardened-build-base:v1.24.9b1"
+      # Trim prefix to get "v1.24.9b1"
+      - trimprefix: "rancher/hardened-build-base:"
+      # Trim 'v' prefix to get "1.24.9b1"
+      - trimprefix: "v"
+      # This regex captures the major.minor to get "1.24"
+      # but it will be a list that will be handled in the next step
+      - findsubmatch:
+          pattern: '^([0-9]+\.[0-9]+)'
+      # Select the last element from the list
+      - kind: lastelement
+
+  # Find the latest release matching that minor version
+  latest_patch:
+    name: Get latest build base patch for that minor
+    kind: githubrelease
+    dependson:
+      - "current_minor"
+    spec:
+      owner: rancher
+      repository: image-build-base
+      token: '{{ requiredEnv .github.token }}'
+      typefilter:
+        release: true
+        draft: false
+        prerelease: false
+      versionfilter:
+        kind: regex
+        # This searches for tags "v1.24.*"
+        # using the "1.24" value from the 'current_minor' source
+        pattern: 'v{{ source "current_minor" }}\.\S+'
+
+targets:
+  dockerfile:
+    name: "Bump to latest build base version in Dockerfile"
+    kind: dockerfile
+    scmid: default
+    sourceid: latest_patch
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: "GO_IMAGE"
+    transformers:
+      - addprefix: "rancher/hardened-build-base:"
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ requiredEnv .github.username }}'
+      user: '{{ .github.user }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump build base version to {{ source "latest_patch" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created
+        scmid: default
+

--- a/updatecli/updatecli.d/updatetraefik.yaml
+++ b/updatecli/updatecli.d/updatetraefik.yaml
@@ -1,0 +1,52 @@
+---
+name: "Update traefik version" 
+
+sources:
+ traefik:
+   name: Get traefik version
+   kind: githubrelease
+   spec:
+     owner: traefik
+     repository: traefik
+     token: '{{ requiredEnv .github.token }}'
+     typefilter:
+       release: true
+       draft: false
+       prerelease: false
+     versionfilter:
+       kind: semver
+
+targets:
+  makefile:
+    name: "Bump to latest traefik version in Makefile"
+    kind: file
+    scmid: default
+    disablesourceinput: true
+    spec:
+      file: Makefile
+      matchpattern: '(?m)^TAG \:\= (.*)'
+      replacepattern: 'TAG := {{ source "traefik" }}$$(BUILD_META)'
+
+scms:
+  default:
+    kind: github
+    spec:
+      token: '{{ requiredEnv .github.token }}'
+      username: '{{ .github.username }}'
+      user: '{{ .github.username }}'
+      email: '{{ .github.email }}'
+      owner: '{{ .github.owner }}'
+      repository: '{{ .github.repository }}'
+      branch: '{{ .github.branch }}'
+      
+actions:
+    default:
+        title: 'Bump traefik version to {{ source "traefik" }}'
+        kind: github/pullrequest
+        spec:
+            automerge: false
+            labels:
+                - chore
+                - skip-changelog
+                - status/auto-created 
+        scmid: default

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "github-actions[bot]"
+  email: "41898282+github-actions[bot]@users.noreply.github.com"
+  username: "UPDATECLI_GITHUB_ACTOR"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  repository: "image-build-traefik"
+  branch: "main"
+  owner: "rancher"


### PR DESCRIPTION
Add updateCLI to publish PRs for new base-image golang versions and new upstream traefik versions.

## Validation
Tested on personal fork:
CI run of updateCLI: https://github.com/dereknola/image-build-traefik/actions/runs/19448122523
Two PRs that were opened:
- https://github.com/dereknola/image-build-traefik/pull/2
- https://github.com/dereknola/image-build-traefik/pull/1