### PR TITLE
Disable prime for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-        push-to-prime: ${{ github.repository_owner == 'rancher' }}
+        # push-to-prime: ${{ github.repository_owner == 'rancher' }}
+        push-to-prime: false
 
     - name: Upload metadata files
       uses: actions/upload-artifact@v4
@@ -145,7 +146,8 @@ jobs:
           prime-registry: ${{ env.PRIME_REGISTRY }}
           prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
           prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-          push-to-prime: ${{ github.repository_owner == 'rancher' }}
+          # push-to-prime: ${{ github.repository_owner == 'rancher' }}
+          push-to-prime: false
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
Salsactl does not yet have a release which includes: https://github.com/rancherlabs/slsactl/pull/212
ecm-distro-tools publish action is still on salsactl 1.2.0: https://github.com/rancher/ecm-distro-tools/blob/master/actions/publish-image/action.yaml#L186C39-L186C54

Disable prime releases until the above has been resolved. 