### PR TITLE
Reenable Prime publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,7 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-        # push-to-prime: ${{ github.repository_owner == 'rancher' }}
-        push-to-prime: false
+        push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
     - name: Upload metadata files
       uses: actions/upload-artifact@v4
@@ -90,8 +89,7 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-        # push-to-prime: ${{ github.repository_owner == 'rancher' }}
-        push-to-prime: false
+        push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
     - name: Upload metadata files
       uses: actions/upload-artifact@v4
@@ -147,8 +145,7 @@ jobs:
           prime-registry: ${{ env.PRIME_REGISTRY }}
           prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
           prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
-          # push-to-prime: ${{ github.repository_owner == 'rancher' }}
-          push-to-prime: false
+          push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
Issues found with https://github.com/rancher/image-build-traefik/pull/14 have now been resolved. ecm-distro-tools is now using salsactl 1.10.0 which includes PR 212
Signed-off-by: Derek Nola <derek.nola@suse.com>