### PR TITLE
Handle multiple remote repository manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: metadata-amd64
-        path: metadata-linux-amd64.json
+        path: metadata-*.json
         if-no-files-found: error
         retention-days: 1
 
@@ -95,10 +95,9 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: metadata-arm64
-        path: metadata-linux-arm64.json
+        path: metadata-*.json
         if-no-files-found: error
         retention-days: 1
-
 
   merge:
     permissions:
@@ -117,6 +116,23 @@ jobs:
         with:
           pattern: metadata-*
           merge-multiple: true
+      
+      - name: Display downloaded files
+        run: ls -la metadata-*
+
+      - name: Set DOCKERHUB_REPO
+        run: |
+          if [ "${{ github.repository_owner }}" == "rancher" ]; then
+            echo "DOCKERHUB_REPO=rancher/hardened-traefik" >> $GITHUB_ENV
+          else
+            echo "DOCKERHUB_REPO=${{ secrets.DOCKER_USERNAME }}/hardened-traefik" >> $GITHUB_ENV
+          fi
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKERHUB_REPO }}
 
       - name: "Read secrets"
         if: github.repository_owner == 'rancher'
@@ -132,6 +148,8 @@ jobs:
       - name: Create manifest list and push
         id: push-manifest
         uses: rancher/ecm-distro-tools/actions/publish-image@master
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
         with:
           make-target: manifest-push
           image: hardened-traefik

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ image-push-digest:
 		--attest type=provenance,mode=max \
 		--progress=plain \
 		--platform=$(TARGET_PLATFORMS) \
-		--metadata-file metadata-$(subst /,-,$(TARGET_PLATFORMS)).json \
+		--metadata-file metadata-$(subst /,-,$(REPO))-$(subst /,-,$(TARGET_PLATFORMS)).json \
 		--output type=image,push-by-digest=true,name-canonical=true,push=true \
 		--pull \
 		--build-arg PKG=$(PKG) \
@@ -58,15 +58,12 @@ image-push-digest:
 image-scan:
 	trivy --severity $(SEVERITIES) --no-progress --ignore-unfixed $(REPO)/hardened-traefik:$(TAG)
 
-# Pushes manifests for the provided TARGET_PLATFORMS
 .PHONY: manifest-push
 manifest-push:
-	$(eval AMD64_DIGEST := $(if $(findstring linux/amd64,$(TARGET_PLATFORMS)),$(shell jq -r '.["containerimage.digest"]' metadata-linux-amd64.json),))
-	$(eval ARM64_DIGEST := $(if $(findstring linux/arm64,$(TARGET_PLATFORMS)),$(shell jq -r '.["containerimage.digest"]' metadata-linux-arm64.json),))
 	docker buildx imagetools create \
 		--tag $(REPO)/hardened-traefik:$(TAG) \
-		$(AMD64_DIGEST) \
-		$(ARM64_DIGEST)
+		$$(jq -r '.["containerimage.digest"]' metadata-$(subst /,-,$(REPO))-linux-amd64.json) \
+		$$(jq -r '.["containerimage.digest"]' metadata-$(subst /,-,$(REPO))-linux-arm64.json)
 
 .PHONY: log
 log:


### PR DESCRIPTION
We generate multiple manifests, one for dockerhub and one for PRIME. We need to account for this when attempting to push a merged manifest. 