### PR TITLE
Add Staging registry and republish latest workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,10 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | STAGING_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | STAGING_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | STAGING_REGISTRY_PASSWORD ;
 
     # For forks, store docker credentials in GHA secrets
     - name: Build and push amd64 digest image 
@@ -43,6 +46,21 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        push-to-prime: ${{ github.repository_owner == 'rancher' }}
+
+    - name: Build and push amd64 digest image (Staging)
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: hardened-traefik
+        make-target: image-push-digest
+        platforms: linux/amd64
+        tag: ${{ github.event.release.tag_name }}
+        push-to-public: false
+        
+        prime-repo: rancher
+        prime-registry: ${{ env.STAGING_REGISTRY }}
+        prime-username: ${{ env.STAGING_REGISTRY_USERNAME }}
+        prime-password: ${{ env.STAGING_REGISTRY_PASSWORD }}
         push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
     - name: Upload metadata files
@@ -71,7 +89,10 @@ jobs:
           secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
           secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | STAGING_REGISTRY ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | STAGING_REGISTRY_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | STAGING_REGISTRY_PASSWORD ;
     
     # For forks, store docker credentials in GHA secrets
     - name: Build and push arm64 digest image 
@@ -89,6 +110,21 @@ jobs:
         prime-registry: ${{ env.PRIME_REGISTRY }}
         prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
         prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
+        push-to-prime: ${{ github.repository_owner == 'rancher' }}
+
+    - name: Build and push arm64 digest image (Staging)
+      uses: rancher/ecm-distro-tools/actions/publish-image@master
+      with:
+        image: hardened-traefik
+        make-target: image-push-digest
+        platforms: linux/arm64
+        tag: ${{ github.event.release.tag_name }}
+        push-to-public: false
+        
+        prime-repo: rancher
+        prime-registry: ${{ env.STAGING_REGISTRY }}
+        prime-username: ${{ env.STAGING_REGISTRY_USERNAME }}
+        prime-password: ${{ env.STAGING_REGISTRY_PASSWORD }}
         push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
     - name: Upload metadata files
@@ -143,7 +179,10 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/dockerhub/${{ github.repository_owner }}/credentials password | DOCKER_PASSWORD ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials registry | PRIME_REGISTRY ;
             secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials username | PRIME_REGISTRY_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-registry/credentials password | PRIME_REGISTRY_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials registry | STAGING_REGISTRY ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials username | STAGING_REGISTRY_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/rancher-prime-stg-registry/credentials password | STAGING_REGISTRY_PASSWORD ;
 
       - name: Create manifest list and push
         id: push-manifest
@@ -165,6 +204,33 @@ jobs:
           prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
           push-to-prime: ${{ github.repository_owner == 'rancher' }}
 
+      - name: Create manifest list and push (Staging)
+        id: push-manifest
+        uses: rancher/ecm-distro-tools/actions/publish-image@master
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        with:
+          make-target: manifest-push
+          image: hardened-traefik
+          tag: ${{ github.event.release.tag_name }}
+          push-to-public: false
+          
+          prime-repo: rancher
+          prime-registry: ${{ env.STAGING_REGISTRY }}
+          prime-username: ${{ env.STAGING_REGISTRY_USERNAME }}
+          prime-password: ${{ env.STAGING_REGISTRY_PASSWORD }}
+          push-to-prime: ${{ github.repository_owner == 'rancher' }}
+
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{ github.repository_owner }}/hardened-traefik:${{ github.event.release.tag_name }}
+
+      - name: Inspect Staging image
+        if: ${{ github.repository_owner == 'rancher' }}
+        run: |
+          docker buildx imagetools inspect ${{ env.STAGING_REGISTRY }}/${{ github.repository_owner }}/hardened-traefik:${{ github.event.release.tag_name }}
+
+      - name: Inspect Prime image
+        if: ${{ github.repository_owner == 'rancher' }}
+        run: |
+          docker buildx imagetools inspect ${{ env.PRIME_REGISTRY }}/${{ github.repository_owner }}/hardened-traefik:${{ github.event.release.tag_name }}

--- a/.github/workflows/republish-latest.yml
+++ b/.github/workflows/republish-latest.yml
@@ -1,0 +1,38 @@
+name: Republish Latest
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile'
+  workflow_dispatch:
+
+permissions:
+    contents: write
+    id-token: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Read Secrets"
+        uses: rancher-eio/read-vault-secrets@main
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/rancher-release-team-auto-tagger/app-credentials appId | APP_ID ;
+            secret/data/github/repo/${{ github.repository }}/github/rancher-release-team-auto-tagger/app-credentials privateKey | PRIVATE_KEY
+
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.PRIVATE_KEY }}
+
+      - name: Republish Latest Release
+        uses: rancher/ecm-distro-tools/actions/republish-latest@master
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          commitish: 'main'
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This PR updates the Release workflow to also push to Staging registry, and add two steps of image inspection for Staging and Prime registries.

It also adds the Republish Latest workflow, where it auto-tags a new release every time there's a change in the `Dockerfile` file.