### PR TITLE
Use apline /etc/passwd in scratch image to support custom OTEL telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN traefik version
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /usr/share/zoneinfo /usr/share/
 COPY --from=builder /usr/local/bin/traefik /
 


### PR DESCRIPTION
https://github.com/rancher/rke2/issues/9990
Signed-off-by: Derek Nola <derek.nola@suse.com>