### PR TITLE
Update `release-on-tag.yml` workflow to use BTAG instead of TAG

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -25,10 +25,12 @@ jobs:
       - name: Calculate release tag from Makefile defaults
         run: |
           TAG=$(make -s log | grep '^TAG=' | cut -d '=' -f2)
+          BTAG=$(make -s log | grep '^BTAG=' | cut -d '=' -f2)
           BUILD_META=$(make -s log | grep '^BUILD_META=' | cut -d '=' -f2)
+          
           echo "TAG=${TAG}" >> "$GITHUB_ENV"
-          echo "BUILD_META=${BUILD_META}" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=${TAG}${BUILD_META}" >> "$GITHUB_ENV"
+          echo "BTAG=${BTAG}" >> "$GITHUB_ENV"
+          echo "RELEASE_TAG=${TAG}" >> "$GITHUB_ENV"
 
       - name: Validate TAG change and release uniqueness
         id: validate
@@ -39,15 +41,15 @@ jobs:
 
           if [[ "${{ github.event_name }}" == "push" ]] && [[ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]]; then
             PREV_TAG=$(git show "${{ github.event.before }}:Makefile" 2>/dev/null | sed -n 's/^TAG := \(.*\)\$(BUILD_META)$/\1/p' | head -n1)
-            if [[ -n "$PREV_TAG" ]] && [[ "$PREV_TAG" == "$TAG" ]]; then
-              echo "Makefile changed, but default TAG did not change ($TAG); skipping release"
+            if [[ -n "$PREV_TAG" ]] && [[ "$PREV_TAG" == "$BTAG" ]]; then
+              echo "Makefile changed, but default TAG did not change ($BTAG); skipping release"
               SHOULD_RELEASE=false
             fi
           fi
 
-          EXISTING_TAG=$(gh release list --limit 200 --json tagName --jq '.[].tagName' | awk -v t="$TAG" 'index($0, t "-build") == 1 {suffix = substr($0, length(t) + 7); if (length(suffix) == 8 && suffix ~ /^[0-9]+$/) {print; exit}}')
+          EXISTING_TAG=$(gh release list --limit 200 --json tagName --jq '.[].tagName' | awk -v t="$BTAG" 'index($0, t "-build") == 1 {suffix = substr($0, length(t) + 7); if (length(suffix) == 8 && suffix ~ /^[0-9]+$/) {print; exit}}')
           if [[ -n "$EXISTING_TAG" ]]; then
-            echo "Release for upstream TAG $TAG already exists as $EXISTING_TAG; skipping release"
+            echo "Release for upstream TAG $BTAG already exists as $EXISTING_TAG; skipping release"
             SHOULD_RELEASE=false
           fi
 


### PR DESCRIPTION
Sample workflow output from my fork: https://github.com/rafaelbreno/image-build-traefik/actions/runs/29590811299/job/87919133351#step:4:28